### PR TITLE
Removes dead links to guides on content page

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -57,14 +57,6 @@
 			<a href="features">Full List Of Features ></a>
 		</div>
 		<div id="content-box">
-			<h2><a href="#" style="text-shadow: none; text-decoration: none">Guides</a></h2>
-			<ul>
-				<li><a href="/content/guide/install_guide">Arch Anywhere Installer</a></li>
-				<li><a href="/content/guide/local_install">Local Arch Install (offline)</a></li>
-				<li><a href="/content/guide/manual_install">Manual Arch Install</a></li>
-			</ul>
-		</div>
-		<div id="content-box">
 			<h2><a href="screenshots" style="text-shadow: none; text-decoration: none">Screenshots</a></h2>	
             <a href="/images/installer/1-issue.png" target="_blank" style="text-decoration: none;">
                 <img src="/images/installer/1-issue.png">


### PR DESCRIPTION
I noticed your repo is not entirely up to date with what is live, but these links are still dead.

Better to remove the dead links and bring them back when the guides are added. 